### PR TITLE
Add function to unpack with custom string decoder

### DIFF
--- a/doc/guile-msgpack.texi
+++ b/doc/guile-msgpack.texi
@@ -513,7 +513,7 @@ wrapping the @code{unpack-from} and @code{unpack} procedures like this:
 This wrapping can also be used to map @code{ext} objects onto whatever they are
 meant to actually represent in your application.
 
-@deffn {Scheme procedure} unpack-from in
+@deffn {Scheme procedure} unpack-from in @ [#:string-decoder=utf8->string]
 Unpacks a single datum from the open binary input port @var{in} and returns the
 unpacked object. If the object is a collection this  procedure is called
 recursively.
@@ -524,10 +524,14 @@ exception @code{empty-port} will be thrown.
 If an object could not be read fully an exception will be raised. Either
 @code{unexpected-eof} if an entire object is missing from a collection (such as
 an array) or another exception if an object could only be read partially.
+
+For legacy code where MessagePack strings are not encoded as UTF-8 you can provide
+a custom @code{string-decoder} procedure to decode a bytevector and return the
+intended string type.
 @end deffn
 
-@deffn {Scheme procedure} unpack bytes
-Unpacks a all data from the bytevector @var{bytes} and returns the unpacked
+@deffn {Scheme procedure} unpack bytes @ [#:string-decoder=utf8->string]
+Unpacks all data from the bytevector @var{bytes} and returns the unpacked
 objects (@pxref{Binding Multiple Values,,,guile}). If @code{bytes} is empty, no
 objects will be returned.
 
@@ -556,6 +560,20 @@ one two hello
 objects
 ⇒ (1 2 "hello")
 @end example
+
+@code{string-decoder} is a custom string decoder, same as in @code{unpack-from}.
+
+@example
+;; The UTF-16 string "Юникод" encoded as a MessagePack fixed length string. But the
+;; default is UTF-8
+(unpack #vu8(#b10101100 #x04 #x2E #x04 #x3D #x4 #x38 #x04 #x3A #x04 #x3E #x4 #x34))
+⇒ "\x04.\x04=\x048\x04:\x04>\x044"
+;; Using a custom decoder
+(unpack #vu8(#b10101100 #x04 #x2E #x04 #x3D #x4 #x38 #x04 #x3A #x04 #x3E #x4 #x34)
+        #:string-decoder utf16->string)
+⇒ "Юникод"
+@end example
+
 @end deffn
 
 @node Procedure Index

--- a/test/unpack/string.scm
+++ b/test/unpack/string.scm
@@ -18,6 +18,7 @@
 ;;; along with msgpack-guile.  If not, see <http://www.gnu.org/licenses/>.
 
 (use-modules (srfi srfi-64)
+             (rnrs bytevectors)
              (test unpack utility test-cases))
 
 
@@ -43,3 +44,21 @@
   ("Unicode" (#xDB #x00 #x00 #x00 #x07 #x55 #x6E #x69 #x63 #x6F #x64 #x65))
   ("Юникод"  (#xDB #x00 #x00 #x00 #x0C #xD0 #xAE #xD0 #xBD #xD0 #xB8 #xD0 #xBA #xD0 #xBE #xD0 #xB4)))
 (test-end "Text Strings")
+
+(test-begin "Custom-string decoder")
+(test-cases-strdec "Fixed length string (utf16)" string=? utf16->string
+  ("Unicode" (#b10101110 #x0 #x55 #x0 #x6e #x0 #x69 #x0 #x63 #x0 #x6f #x0 #x64 #x0 #x65))
+  ("Юникод" (#b10101100 #x04 #x2E #x04 #x3D #x4 #x38 #x04 #x3A #x04 #x3E #x4 #x34)))
+(test-cases-strdec "8-bit string (utf16)" string=? utf16->string
+  ("Unicode" (#xD9 #x0E #x0 #x55 #x0 #x6e #x0 #x69 #x0 #x63 #x0 #x6f #x0 #x64 #x0 #x65))
+  ("Юникод"  (#xD9 #x0C #x04 #x2E #x04 #x3D #x4 #x38 #x04 #x3A #x04 #x3E #x4 #x34)))
+(test-cases-strdec "16-bit string (utf16)" string=? utf16->string
+  ("Unicode" (#xDA #x00 #x0E #x0 #x55 #x0 #x6e #x0 #x69 #x0 #x63 #x0 #x6f #x0 #x64 #x0 #x65))
+  ("Юникод"  (#xDA #x00 #x0C #x04 #x2E #x04 #x3D #x4 #x38 #x04 #x3A #x04 #x3E #x4 #x34)))
+(test-cases-strdec "32-bit string (utf16)" string=? utf16->string
+  ("Unicode" (#xDB #x00 #x00 #x00 #x0E #x0 #x55 #x0 #x6e #x0 #x69 #x0 #x63 #x0 #x6f #x0 #x64 #x0 #x65))
+  ("Юникод"  (#xDB #x00 #x00 #x00 #x0C #x04 #x2E #x04 #x3D #x4 #x38 #x04 #x3A #x04 #x3E #x4 #x34)))
+
+(test-cases-strdec "Decode string as another type" = (lambda (bv) 42)
+  (42 (#b10100111 #x55 #x6e #x69 #x63 #x6f #x64 #x65)))
+(test-end "Custom-string decoder")

--- a/test/unpack/utility/test-cases.scm
+++ b/test/unpack/utility/test-cases.scm
@@ -23,7 +23,7 @@
   #:use-module ((srfi srfi-1)      #:select (append-map))
   #:use-module ((srfi srfi-64)     #:select (test-begin test-end test-assert))
   #:use-module ((ice-9 match)      #:select (match-lambda))
-  #:export (test-cases test-case))
+  #:export (test-cases test-case test-cases-strdec test-case-strdec))
 
 ;; Test cases are specified as (test-case expected given), where 'expected' is
 ;; the unpacked object we expect, and 'given' is a specification of bytes to
@@ -55,6 +55,24 @@
     ((_ pred expected (spec ...))
      (test-assert (pred expected
                         (unpack (compact-bytevector (syntax->datum #'(spec ...)))))))))
+
+(define-syntax test-cases-strdec
+  (syntax-rules ()
+    ((_ title pred dec
+       (expected (spec ...))
+       ...)
+     (begin
+       (test-begin title)
+       (test-case-strdec pred dec expected (spec ...))
+       ...
+       (test-end title)))))
+
+(define-syntax test-case-strdec
+  (syntax-rules ()
+    ((_ pred string-decoder expected (spec ...))
+     (test-assert (pred expected
+                        (unpack (compact-bytevector (syntax->datum #'(spec ...)))
+                          #:string-decoder string-decoder))))))
 
 (define (compact-bytevector specs)
   "Convert a series of of (count byte ...) or single byte specifications into a


### PR DESCRIPTION
Hi, I've been using guile-msgpack for a while and it works great, but there is one feature I've been missing - being able to have custom decoder for the string type. I have two use cases for this:

1. decoding non utf8 strings
2. keeping strings in their original encoding as byte arrays

This is a bit WIP, since the function names are silly. But I decided to open this to get some early feedback. Let me know if you think approach is appropriate or not. I added two new functions, but the same could be achieved with optional/keyword arguments.